### PR TITLE
Update multi_k_model.py

### DIFF
--- a/dna2vec/multi_k_model.py
+++ b/dna2vec/multi_k_model.py
@@ -4,7 +4,7 @@ import logbook
 import tempfile
 import numpy as np
 
-from gensim.models import word2vec
+from gensim.models import KeyedVectors
 from gensim import matutils
 
 class SingleKModel:
@@ -14,7 +14,7 @@ class SingleKModel:
 
 class MultiKModel:
     def __init__(self, filepath):
-        self.aggregate = word2vec.Word2Vec.load_word2vec_format(filepath, binary=False)
+        self.aggregate = KeyedVectors.load_word2vec_format(filepath, binary=False)
         self.logger = logbook.Logger(self.__class__.__name__)
 
         vocab_lens = [len(vocab) for vocab in self.aggregate.vocab.keys()]
@@ -56,4 +56,4 @@ class MultiKModel:
                 vec_str = ' '.join("%f" % val for val in self.aggregate[vocab])
                 print('{} {}'.format(vocab, vec_str), file=fptr)
             fptr.flush()
-            return SingleKModel(word2vec.Word2Vec.load_word2vec_format(fptr.name, binary=False))
+            return SingleKModel(KeyedVectors.load_word2vec_format(fptr.name, binary=False))


### PR DESCRIPTION
In the existing version when calling the `MultiKModel` class the following error appears:

>DeprecationWarning: Deprecated appears. Use gensim.models.KeyedVectors.load_word2vec_format instead.

The solution is to change the import library to `KeyedVectors`.